### PR TITLE
Fixing 'unraveling -1' in the weighted random sampler.

### DIFF
--- a/torchio/data/sampler/weighted.py
+++ b/torchio/data/sampler/weighted.py
@@ -219,13 +219,9 @@ class WeightedSampler(RandomSampler):
         """  # noqa: E501
         # Get first value larger than random number ensuring the random number
         # is not exactly 0 (see https://github.com/fepegar/torchio/issues/510)
-        random_number = max(MIN_FLOAT_32, torch.rand(1).item())
+        random_number = max(MIN_FLOAT_32, torch.rand(1).item()) * cdf[-1]
 
-        # Accumulated floating point errors might make cdf.max() less than 1
-        if random_number > cdf.max():
-            random_location_index = -1
-        else:  # proceed as usual
-            random_location_index = np.searchsorted(cdf, random_number)
+        random_location_index = np.searchsorted(cdf, random_number)
 
         center = np.unravel_index(
             random_location_index,


### PR DESCRIPTION
Additional micro-optimization: cdf is monotonically increasing, cdf[-1] is the maximum always,
no need to calculate it.

<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
Fixes #{issue_number}.

**Description**
A few sentences describing the changes proposed in this pull request.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [ ] I have read the [`CONTRIBUTING`](https://github.com/fepegar/torchio/blob/master/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [ ] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [ ] This pull request is ready to be reviewed
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)
